### PR TITLE
fix: SSE hook API URL fallback 추가

### DIFF
--- a/frontend/hooks/use-sse.ts
+++ b/frontend/hooks/use-sse.ts
@@ -58,7 +58,8 @@ export function useSSE({ matchId, blockId, enabled }: UseSSEProps): UseSSEReturn
         setSeatMap(new Map());
         setStatus('reconnecting');
 
-        const url = `${process.env.NEXT_PUBLIC_API_URL}/matches/${matchId}/blocks/${blockId}/seats/events`;
+        const validApiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080/api';
+        const url = `${validApiUrl}/matches/${matchId}/blocks/${blockId}/seats/events`;
         console.log('Connecting to SSE:', url);
 
         const es = new EventSource(url);


### PR DESCRIPTION
## 변경 요약

NEXT_PUBLIC_API_URL 환경변수 미설정 시 SSE 연결이 실패하는 문제를 수정한다.

## 버그 상세

### 현상

환경변수 미설정 시 `undefined/matches/...` URL로 SSE 연결 시도하여 실패

### 원인

`process.env.NEXT_PUBLIC_API_URL`이 undefined일 때 fallback 처리 없음

### 해결 방법

`process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080/api'` fallback 추가

## 영향 범위

- [x] Frontend

## 체크리스트

- [x] 버그 재현 확인
- [x] 셀프 리뷰 완료

Closes #52